### PR TITLE
force plts option

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -24,9 +24,11 @@
 
 #include "config.h"
 #include "log.h"
+#include "option.h"
 
-satipConfig::satipConfig(int fe_type):
+satipConfig::satipConfig(int fe_type, vtunerOpt* settings):
 	m_fe_type(fe_type),
+	m_settings(settings),
 	m_signal_source(1),
 	m_pol(CONFIG_POL_HORIZONTAL),
 	m_status(CONFIG_STATUS_CHANNEL_INVALID),
@@ -334,6 +336,8 @@ std::string satipConfig::getTuningData()
 			}
 
 			/* rilots */
+			if(m_settings->m_force_plts)
+        m_pilot = PILOT_ON;
 			switch (m_pilot)
 			{
 				case PILOT_ON: 	oss_data << "&plts=on"; break;

--- a/config.h
+++ b/config.h
@@ -24,6 +24,8 @@
 #include <string>
 #include <linux/dvb/frontend.h>
 
+#include "option.h"
+
 #define MAX_PIDS 30 // from usbtunerhelper
 
 typedef unsigned short u16;
@@ -69,7 +71,7 @@ typedef enum
 class satipConfig
 {
 public:
-	satipConfig(int fe_type);
+	satipConfig(int fe_type, vtunerOpt* settings);
 	virtual ~satipConfig();
 
 	int getFeType() {return m_fe_type;}
@@ -182,6 +184,8 @@ private:
 	t_pid_status m_pid_status;
 
 	t_lnb_onoff m_lnb_voltage_onoff;
+	
+	vtunerOpt* m_settings;
 
 	std::string getTuningData();
 };

--- a/manager.cpp
+++ b/manager.cpp
@@ -56,18 +56,18 @@ void sessionManager::satipStart()
 			if (it->second.isAvailable())
 			{
 				DEBUG(MSG_MAIN, "try connect : [%d] type : %s, ip : %s, fe_type : %d\n", it->first, it->second.m_vtuner_type.c_str(), it->second.m_ipaddr.c_str(), it->second.m_fe_type);
-				satipSessionCreate(it->second.m_ipaddr.c_str(), it->second.m_fe_type);
+				satipSessionCreate(it->second.m_ipaddr.c_str(), it->second.m_fe_type, &(it->second));
 			}
 		}
 	}
 }
 
-int sessionManager::satipSessionCreate(const char* ipaddr, int fe_type)
+int sessionManager::satipSessionCreate(const char* ipaddr, int fe_type, vtunerOpt* settings)
 {
 	int ok = 0;
 
 	Session* session;
-	session = new satipSession( ipaddr, default_port, fe_type, ok);
+	session = new satipSession( ipaddr, default_port, fe_type, settings, ok);
 	if (!ok) 
 	{
 		DEBUG(MSG_MAIN, "Session init failed!\n");

--- a/manager.h
+++ b/manager.h
@@ -36,7 +36,7 @@ class sessionManager
 	std::list<Session*> m_sessions;
 	optParser m_satip_opt;
 
-	int satipSessionCreate(const char* ipaddr, int fe_type);
+	int satipSessionCreate(const char* ipaddr, int fe_type, vtunerOpt* settings);
 	void addSession(Session* session) { m_sessions.push_back(session); }
 
 public:

--- a/option.cpp
+++ b/option.cpp
@@ -105,6 +105,9 @@ void optParser::load()
 
 			else if (attr[0] == "tuner_type")
 				m_settings[index].m_fe_type = tuner_type_table[attr[1]];
+
+                        else if (attr[0] == "force_plts" && attr[1] == "1")
+                                m_settings[index].m_force_plts = true;
 		}
 	}
 }

--- a/option.h
+++ b/option.h
@@ -30,8 +30,9 @@ public:
 	std::string m_vtuner_type;
 	std::string m_ipaddr;
 	int m_fe_type;
+        bool m_force_plts;
 
-	vtunerOpt():m_fe_type(-1)
+	vtunerOpt():m_fe_type(-1),m_force_plts(false)
 	{
 	}
 

--- a/session.cpp
+++ b/session.cpp
@@ -27,10 +27,12 @@
 #include "rtp.h"
 #include "rtsp.h"
 #include "log.h"
+#include "option.h"
 
 satipSession::satipSession(const char* host,
 							const char* rtsp_port,
 							int fe_type,
+							vtunerOpt* settings,
 							int& initok):
 							m_satip_config(NULL),
 							m_satip_vtuner(NULL),
@@ -41,7 +43,7 @@ satipSession::satipSession(const char* host,
 {
 	DEBUG(MSG_MAIN,"Create SESSION.(host : %s, rtsp_port : %s, fe_type : %d\n",
 		host, rtsp_port, fe_type);
-	m_satip_config = new satipConfig(fe_type );
+	m_satip_config = new satipConfig(fe_type, settings);
 	m_satip_vtuner = new satipVtuner(m_satip_config);
 	m_satip_rtp  = new satipRTP(m_satip_vtuner->getVtunerFd());
 

--- a/session.h
+++ b/session.h
@@ -23,6 +23,7 @@
 #include "rtsp.h"
 #include "rtp.h"
 #include "session.h"
+#include "option.h"
 
 #include <string>
 #include <pthread.h>
@@ -53,6 +54,7 @@ public:
 	satipSession(const char* host,
 							const char* rtsp_port,
 							int fe_type,
+							vtunerOpt* m_settings,
 							int& initok);
 
 	virtual ~satipSession();


### PR DESCRIPTION
suggestion for adding a vtuner.conf option for forcing pilot on dvbs2 (force_plts:1).
my Triax TSS 400 MKII apparently needs this if the first tuned channel is dvbs2.
tvheadend has a similar option: "Force pilot for DVB-S2 : Enable if the SAT>IP box request plts=on parameter in the SETUP RTSP command for DVB-S2 muxes."
