### PR TITLE
auto detect and avoid ioctl conflicts

### DIFF
--- a/vtuner.h
+++ b/vtuner.h
@@ -25,6 +25,7 @@
 
 #define VTUNER_PIDLIST_LEN 30 // from usbtunerhelper
 
+#include <linux/ioctl.h>
 #include <linux/dvb/version.h>
 #include <linux/dvb/frontend.h>
 #include <linux/dvb/dmx.h>
@@ -135,7 +136,7 @@ struct vtuner_message
 #endif
 
 
-#if VMSG_TYPE2
+#if _IOC_NONE == 0
 #define VTUNER_GET_MESSAGE  11
 #define VTUNER_SET_RESPONSE 12
 #define VTUNER_SET_NAME     13


### PR DESCRIPTION
The vtuner interface does not use proper ioctl defines, causing
potential ioctl number conflicts with kernel built-in ioctls (such as
the bmap ioctls).
Whether or not these conflicts will occur, depends on the architecture
definition of _IOC_NONE. When _IOC_NONE is zero, the vtuner ioctls 1 and
2 will conflict with the bmap ioctls, therefore we should not use them.
Instead, use higher numbers in that case and expect the vtuner driver on
that particular platform to support them.
(this would have been a good time to introduce proper ioctl numbers
using the ioctl macros, however we do depend on the vtuner driver
developers to make those definitions)

Auto detecting and working around this situation avoids the need to
create manual exceptions for each new platform to be supported.
VMSG_TYPE2 no longer needs to be defined.