### PR TITLE
fix queries and keep alive

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -315,36 +315,35 @@ std::string satipConfig::getTuningData()
 			default:	break;
 		}
 
-		/* for dvb-s2 */
-		if (m_msys == SYS_DVBS2)
-		{
-			/* rolloff */
-			switch (m_rolloff)
-			{
-				case ROLLOFF_35:	oss_data << "&ro=0.35"; break;
-				case ROLLOFF_20:	oss_data << "&ro=0.20"; break;
-				case ROLLOFF_25:	oss_data << "&ro=0.25"; break;
-				default:	break;
-			}
+        /* rolloff */
+        switch (m_rolloff)
+        {
+            case ROLLOFF_35:	oss_data << "&ro=0.35"; break;
+            case ROLLOFF_20:	oss_data << "&ro=0.20"; break;
+            case ROLLOFF_25:	oss_data << "&ro=0.25"; break;
+            default:            oss_data << "&ro=0.35"; break;
+        }
 
-			/* modulation type */
-			switch (m_mtype)
-			{
-				case QPSK:	oss_data << "&mtype=qpsk"; break;
-				case PSK_8:	oss_data << "&mtype=8psk"; break;
-				default:	break;
-			}
+        /* modulation type */
+        switch (m_mtype)
+        {
+            case QPSK:	oss_data << "&mtype=qpsk"; break;
+            case PSK_8:	oss_data << "&mtype=8psk"; break;
+            default:	oss_data << "&mtype=qpsk"; break;
+        }
 
-			/* rilots */
-			if(m_settings->m_force_plts)
-        m_pilot = PILOT_ON;
-			switch (m_pilot)
-			{
-				case PILOT_ON: 	oss_data << "&plts=on"; break;
-				case PILOT_OFF: oss_data << "&plts=off"; break;
-				default: break;
-			}
-		}
+        /* pilots */
+        if(m_settings->m_force_plts)
+            m_pilot = PILOT_ON;
+        else
+            m_pilot = PILOT_OFF;
+
+        switch (m_pilot)
+        {
+            case PILOT_ON: 	oss_data << "&plts=on"; break;
+            case PILOT_OFF: oss_data << "&plts=off"; break;
+            default: break;
+        }
 		
 	}
 	else if (m_fe_type == FE_TYPE_CABLE)

--- a/rtsp.cpp
+++ b/rtsp.cpp
@@ -78,7 +78,7 @@ void satipRTSP::resetConnect()
 	m_rtsp_cseq = 1;
 	m_rtsp_session_id.clear();
 	m_rtsp_stream_id = -1;
-	m_rtsp_timeout = 30;
+    m_rtsp_timeout = 60;
 
 	m_rx_data_pos = 0;
 
@@ -546,7 +546,7 @@ int satipRTSP::sendOption()
 
 	oss_tx_data << "OPTIONS rtsp://" << m_host << ":" << m_port << "/";
 //	if (m_rtsp_stream_id != -1)
-	oss_tx_data << "stream=" << m_rtsp_stream_id;
+//	oss_tx_data << "stream=" << m_rtsp_stream_id;
 	oss_tx_data << " RTSP/1.0\r\n";
 
 	oss_tx_data << "CSeq: " << m_rtsp_cseq++ << "\r\n";


### PR DESCRIPTION
config.cpp - add ro, mtype , plts for DVBS (see SAT>IP 1.2.2).
rtsp.cpp   - remove "stream=" from OPTIONS.
rtsp.cpp   - set the default timeout to 60 seconds.