### PR TITLE
initial RTP/TCP/AVP transport mode support

### DIFF
--- a/config.h
+++ b/config.h
@@ -74,6 +74,7 @@ public:
 	satipConfig(int fe_type, vtunerOpt* settings);
 	virtual ~satipConfig();
 
+	bool isTcpData() {return m_settings->m_tcpdata;}
 	int getFeType() {return m_fe_type;}
 
 	/* vtuner property */

--- a/option.cpp
+++ b/option.cpp
@@ -103,6 +103,9 @@ void optParser::load()
 			else if (attr[0] == "ipaddr")
 				m_settings[index].m_ipaddr = attr[1];
 
+			else if (attr[0] == "tcpdata" && attr[1] == "1")
+				m_settings[index].m_tcpdata = true;
+
 			else if (attr[0] == "tuner_type")
 				m_settings[index].m_fe_type = tuner_type_table[attr[1]];
 

--- a/option.h
+++ b/option.h
@@ -29,6 +29,7 @@ class vtunerOpt
 public:
 	std::string m_vtuner_type;
 	std::string m_ipaddr;
+	bool m_tcpdata;
 	int m_fe_type;
         bool m_force_plts;
 

--- a/rtp.cpp
+++ b/rtp.cpp
@@ -36,7 +36,7 @@
 #define PORT_BASE 45000
 #define PORT_RANGE 2000
 
-satipRTP::satipRTP(int vtuner_fd)
+satipRTP::satipRTP(int vtuner_fd, int tcp_data)
 						:m_rtp_port(-1),
 						m_rtp_socket(-1),
 						m_rtcp_port(-1),
@@ -50,9 +50,14 @@ satipRTP::satipRTP(int vtuner_fd)
 {
 	DEBUG(MSG_MAIN,"Create RTP.\n");
 	m_vtuner_fd = vtuner_fd;
-	m_openok = !openRTP();
-	if (!m_openok)
-		DEBUG(MSG_MAIN,"Create RTP failed.\n");
+	m_tcp_data = tcp_data;
+	if (tcp_data) {
+		m_openok = 1;
+	} else {
+		m_openok = !openRTP();
+		if (!m_openok)
+			DEBUG(MSG_MAIN,"Create RTP failed.\n");
+	}
 }
 
 satipRTP::~satipRTP()
@@ -335,6 +340,28 @@ void* satipRTP::rtpDump()
 	return 0;
 }
 
+int satipRTP::rtpTcpData(unsigned char *data, int size)
+{
+        if (size <= 4 + 12)
+        {
+                return 0;
+        }
+
+        if (data[1] == 0)
+        {
+                int wr = Write(m_vtuner_fd, data + 4 + 12, size - 4 - 12);
+                DEBUG(MSG_DATA, "RTP TCP DATA : read %d bytes, write %d bytes\n", size - 4, wr);
+        }
+        else if (data[1] == 1)
+        {
+                DEBUG(MSG_DATA,"RTCP TCP DATA : read %d bytes\n", size - 4);
+                rtcpData(data + 4, size - 4);
+
+        }
+
+        return 0;
+}
+
 void *satipRTP::thread_wrapper(void *ptr)
 {
 	return ((satipRTP*)ptr)->rtpDump();
@@ -343,7 +370,8 @@ void *satipRTP::thread_wrapper(void *ptr)
 void satipRTP::run()
 {
 	m_running = true;
-	pthread_create( &m_thread, NULL, thread_wrapper, this);
+	if (!m_tcp_data)
+		pthread_create( &m_thread, NULL, thread_wrapper, this);
 }
 
 void satipRTP::stop()

--- a/rtp.h
+++ b/rtp.h
@@ -30,6 +30,7 @@ class satipRTP
 	int m_rtcp_port;
 	int m_rtcp_socket;
 	pthread_t m_thread;
+	bool m_tcp_data;
 	bool m_running;
 
 	/* rtcp data */
@@ -46,7 +47,7 @@ class satipRTP
 	int openRTP();
 
 public:
-	satipRTP(int vtuner_fd);
+	satipRTP(int vtuner_fd, int tcp_data);
 	virtual ~satipRTP();
 	int get_rtp_port() { return m_rtp_port; }
 	int get_rtp_socket() { return m_rtp_socket; }
@@ -56,6 +57,7 @@ public:
 
 	int Write(int fd, unsigned char *buffer, int size);
 	ssize_t Read(int fd, unsigned char *buffer, int size);
+	int rtpTcpData(unsigned char *data, int size);
 	void run();
 	void stop();
 

--- a/rtsp.cpp
+++ b/rtsp.cpp
@@ -40,10 +40,10 @@
 satipRTSP::satipRTSP(satipConfig* satip_config,
 			     const char* host, 
 			     const char* rtsp_port,
-			     int rtp_port):
+			     satipRTP *rtp):
 			     m_host(NULL),
 			     m_port(NULL),
-			     m_rtp_port(rtp_port),
+			     m_rtp(rtp),
 			     m_satip_config(satip_config),
 			     m_timer_reset_connect(NULL),
 			     m_timer_keep_alive(NULL),
@@ -53,7 +53,14 @@ satipRTSP::satipRTSP(satipConfig* satip_config,
 			     m_rtsp_request(RTSP_REQUEST_NONE),
 			     m_wait_response(false)
 {
-	DEBUG(MSG_MAIN,"Create RTSP. (host : %s, port : %s, rtp_port : %d)\n", host, rtsp_port, rtp_port);
+	if (satip_config->isTcpData()) {
+		DEBUG(MSG_MAIN,"Create RTSP. (host : %s, port : %s, TCP data mode)\n", host, rtsp_port);
+		m_rx_data_len = 256*1024;
+	} else {
+		DEBUG(MSG_MAIN,"Create RTSP. (host : %s, port : %s, rtp_port : %d)\n", host, rtsp_port, m_rtp->get_rtp_port());
+		m_rx_data_len = 2048;
+	}
+	m_rx_data = (char *)malloc(m_rx_data_len);
 	m_host=strdup(host);
 	m_port=strdup(rtsp_port);
 
@@ -66,6 +73,7 @@ satipRTSP::satipRTSP(satipConfig* satip_config,
 satipRTSP::~satipRTSP()
 {
 	DEBUG(MSG_MAIN,"Destruct RTSP.\n");
+	free(m_rx_data);
 	free(m_host);
 	free(m_port);
 }
@@ -78,7 +86,7 @@ void satipRTSP::resetConnect()
 	m_rtsp_cseq = 1;
 	m_rtsp_session_id.clear();
 	m_rtsp_stream_id = -1;
-    m_rtsp_timeout = 60;
+	m_rtsp_timeout = 60;
 
 	m_rx_data_pos = 0;
 
@@ -175,6 +183,19 @@ int satipRTSP::connectToServer()
 		return RTSP_ERROR;
 	}
 
+	if (m_satip_config->isTcpData()) {
+		int len = 1024 * 1024;
+		if (setsockopt(fd, SOL_SOCKET, SO_RCVBUFFORCE, &len, sizeof(len)))
+			WARN(MSG_MAIN, "unable to set TCP buffer (force) size to %d\n", len);
+
+                if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &len, sizeof(len)))
+                        WARN(MSG_MAIN, "unable to set TCP buffer size to %d\n", len);
+
+                socklen_t sl = sizeof(int);
+                if (!getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &len, &sl))
+                        DEBUG(MSG_DATA, "TCP buffer size is %d bytes\n", len);
+	}
+
 	freeaddrinfo(result);
 
 	m_fd = fd;
@@ -186,25 +207,57 @@ int satipRTSP::handleResponse()
 {
 	int res = RTSP_ERROR;
 	int res_code = 0;
-	ssize_t read_data = recv(m_fd, &(m_rx_data[m_rx_data_pos]), sizeof(m_rx_data) - m_rx_data_pos, 0);
+	size_t len = m_rx_data_len - m_rx_data_pos - 1;
+
+	if (len == 0)
+	{
+		ERROR(MSG_MAIN, "RTSP : RX buffer overflow");
+		m_rx_data_pos = 0;
+		return RTSP_ERROR;
+	}
+
+	ssize_t read_data = recv(m_fd, &(m_rx_data[m_rx_data_pos]), len, 0);
 
 	if (read_data == 0)
 	{
 		return RTSP_ERROR;
 	}
 
+	DEBUG(MSG_NET, "RTSP: RX %zd/%d\n", read_data, m_rx_data_pos);
+
 	m_rx_data_pos += read_data;
+
+again:
+	while (m_rx_data[0] == '$') {
+		if (!m_satip_config->isTcpData()) {
+			return RTSP_ERROR;
+		}
+		if (m_rx_data_pos < 4)
+		{
+			return RTSP_OK;
+		}
+		size_t len2 = 4 + (((unsigned char)m_rx_data[2] << 8) | (unsigned char)m_rx_data[3]);
+		if (m_rx_data_pos < len2)
+		{
+			return RTSP_OK;
+		}
+		int r = m_rtp->rtpTcpData((unsigned char *)m_rx_data, len2);
+		memmove(m_rx_data, m_rx_data + len2, m_rx_data_pos - len2);
+		m_rx_data_pos -= len2;
+		if (r)
+		{
+			return RTSP_ERROR;
+		}
+	}
+
 	m_rx_data[m_rx_data_pos] = 0;
 
-	DEBUG(MSG_NET,"RTSP rx data : \n%s\n", m_rx_data);
-
-	if (strstr(m_rx_data, "\r\n\r\n") == NULL)
+	char *s = strstr(m_rx_data, "\r\n\r\n");
+	DEBUG(MSG_NET,"RTSP rx data (%p/%i) : \n%s\n", s, m_rx_data_pos, m_rx_data);
+	if (s == NULL)
 	{
 		return RTSP_OK;
 	}
-
-	/* receive data complete */
-	m_rx_data_pos = 0;
 
 	/* set response wait to false */
 	m_wait_response = false;
@@ -213,13 +266,15 @@ int satipRTSP::handleResponse()
 	if (m_rtsp_request == RTSP_REQUEST_DESCRIBE)
 	{
 		stopTimerResetConnect();
-		m_rtsp_request = RTSP_REQUEST_NONE;
-		return handleResponseDescribe();
+		res = handleResponseDescribe();
+		goto complete;
 	}
 
 	sscanf(m_rx_data,"RTSP/%*s %d",&res_code);
-	if (res_code!=200)
+	if (res_code!=200) {
+		m_rx_data_pos = 0;
 		return RTSP_ERROR;
+	}
 
 	switch(m_rtsp_request)
 	{
@@ -277,7 +332,18 @@ int satipRTSP::handleResponse()
 		stopTimerResetConnect();
 	}
 
+complete:
+	/* receive data complete */
+	size_t len2 = m_rx_data_pos - (4 + (s - m_rx_data));
+	memmove(m_rx_data, s + 4, len2);
+	m_rx_data_pos = len2;
+	DEBUG(MSG_NET,"RTSP rx data end (%i)\n", m_rx_data_pos);
+
 	m_rtsp_request = RTSP_REQUEST_NONE;
+
+	if (len2 > 0) {
+		goto again;
+	}
 
 	return res;
 }
@@ -420,7 +486,7 @@ int satipRTSP::sendRequest(int request)
 	{
 		m_wait_response = true;
 		m_rtsp_request = request;
-		startTimerResetConnect(2000); // server connect timer start
+		startTimerResetConnect(4000); // server connect timer start
 	}
 	else
 	{
@@ -474,7 +540,12 @@ int satipRTSP::sendSetup()
 	if (!m_rtsp_session_id.empty())
 		oss_tx_data << "Session: " << m_rtsp_session_id << "\r\n";
 
-	oss_tx_data << "Transport: RTP/AVP;unicast;client_port=" << m_rtp_port << "-" << m_rtp_port +1 << "\r\n";
+	if (m_satip_config->isTcpData()) {
+		oss_tx_data << "Transport: RTP/AVP/TCP;interleaved=0-1\r\n";
+	} else {
+		int rtp_port = m_rtp->get_rtp_port();
+		oss_tx_data << "Transport: RTP/AVP;unicast;client_port=" << rtp_port << "-" << rtp_port+1 << "\r\n";
+	}
 	oss_tx_data << "\r\n";
 
 	tx_data = oss_tx_data.str();
@@ -709,7 +780,10 @@ short satipRTSP::getPollEvent()
 	switch(m_rtsp_status)
 	{
 		case RTSP_STATUS_CONFIG_WAITING:
-			events = 0; // no poll
+			if ( m_satip_config->isTcpData() ) // TCP data mode
+				events = POLLIN | POLLHUP;
+			else
+				events = 0; // no poll
 			break;
 
 		case RTSP_STATUS_SERVER_CONNECTING: // connected to serverm check if server ready to send RTSP requests.
@@ -725,7 +799,8 @@ short satipRTSP::getPollEvent()
 			break;
 
 		case RTSP_STATUS_SESSION_TRANSMITTING:
-			if ( m_rtsp_request == RTSP_REQUEST_OPTION) // keep alive message
+			if ( m_rtsp_request == RTSP_REQUEST_OPTION ||  // keep alive message
+			     m_satip_config->isTcpData() )             // or TCP data mode
 				events = POLLIN | POLLHUP;
 			else
 				events = 0; // no poll

--- a/rtsp.h
+++ b/rtsp.h
@@ -22,6 +22,7 @@
 
 #include "timer.h"
 #include "config.h"
+#include "rtp.h"
 #include <string>
 
 enum 
@@ -50,7 +51,7 @@ public:
 	satipRTSP(satipConfig* satip_config,
 			     const char* host, 
 			     const char* rtsp_port,
-			     int rtp_port);
+			     satipRTP *rtp);
 	~satipRTSP();
 	void handleRTSPStatus();
 	int getRtspSocketFd();
@@ -66,7 +67,7 @@ public:
 private:
 	char *m_host;
 	char* m_port;
-	int m_rtp_port;
+	satipRTP *m_rtp;
 	satipConfig *m_satip_config;
 	satipTimer m_satip_timer;
 	timer_elem *m_timer_reset_connect;
@@ -74,7 +75,8 @@ private:
 	int m_fd;
 
 	char m_txbuf[1024];
-	char m_rx_data[1024];
+	char *m_rx_data;
+	int m_rx_data_len;
 	int m_rx_data_pos;
 
 	int m_rtsp_status;
@@ -91,6 +93,8 @@ private:
 	
 	void resetConnect();
 	int connectToServer();
+
+	int rtpData(size_t len);
 
 	int handleResponse();
 	int handleResponseSetup();

--- a/session.cpp
+++ b/session.cpp
@@ -41,15 +41,17 @@ satipSession::satipSession(const char* host,
 							m_session_thread(0),
 							m_running(false)
 {
+	int rtp_port;
+
 	DEBUG(MSG_MAIN,"Create SESSION.(host : %s, rtsp_port : %s, fe_type : %d\n",
 		host, rtsp_port, fe_type);
 	m_satip_config = new satipConfig(fe_type, settings);
 	m_satip_vtuner = new satipVtuner(m_satip_config);
-	m_satip_rtp  = new satipRTP(m_satip_vtuner->getVtunerFd());
+	m_satip_rtp  = new satipRTP(m_satip_vtuner->getVtunerFd(), settings->m_tcpdata);
 
 	m_satip_vtuner->setSatipRTP(m_satip_rtp); // for receive RTCP data
 
-	m_satip_rtsp = new satipRTSP(m_satip_config, host, rtsp_port, m_satip_rtp->get_rtp_port());
+	m_satip_rtsp = new satipRTSP(m_satip_config, host, rtsp_port, m_satip_rtp);
 
 	if (m_satip_vtuner->isOpened() && m_satip_rtp->isOpened())
 		initok = 1;


### PR DESCRIPTION
This patch adds support for the RTP/TCP/AVP interleaved data in the RTSP TCP connection. It resolves the occasional packet loss on the ethernet network. The code is tested on vusolo2 .