### PR TITLE
Add support for fe: in /etc/vtuner.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # satipclient
 SAT>IP Client FORK from: https://code.google.com/p/satip/
+
+Supported options in /etc/vtuners.conf:
+- tcpdata:1 - uses TCP instead of UDP for the connection with the satip server
+- force_plts:1 - forces sending plts=on as part of the satip request
+- fe:X - send fe=X as part of the satip request to force a specific adapter (useful on multiple satellite connections on different adapters)

--- a/config.cpp
+++ b/config.cpp
@@ -286,6 +286,9 @@ std::string satipConfig::getTuningData()
 	std::string data;
 	std::ostringstream oss_data;
 
+	if (m_settings->m_fe_number > 0)
+		oss_data << "&fe=" << m_settings->m_fe_number;
+
 	if (m_fe_type == FE_TYPE_SAT)
 	{
 		oss_data << "&src=" << m_signal_source;

--- a/option.cpp
+++ b/option.cpp
@@ -41,7 +41,7 @@ void optParser::dump()
 	std::map<int, vtunerOpt>::iterator it;
 	for (it = m_settings.begin(); it!=m_settings.end(); it++)
 	{
-		DEBUG(MSG_MAIN, "[%d] tuner type : %s, ip : %s, fe_type : %d\n", it->first, it->second.m_vtuner_type.c_str(), it->second.m_ipaddr.c_str(), it->second.m_fe_type);
+		DEBUG(MSG_MAIN, "[%d] tuner type : %s, ip : %s, fe_type : %d, fe_number : %d\n", it->first, it->second.m_vtuner_type.c_str(), it->second.m_ipaddr.c_str(), it->second.m_fe_type, it->second.m_fe_number);
 	}
 }
 
@@ -109,8 +109,10 @@ void optParser::load()
 			else if (attr[0] == "tuner_type")
 				m_settings[index].m_fe_type = tuner_type_table[attr[1]];
 
-                        else if (attr[0] == "force_plts" && attr[1] == "1")
-                                m_settings[index].m_force_plts = true;
+            else if (attr[0] == "force_plts" && attr[1] == "1")
+                m_settings[index].m_force_plts = true;
+            else if (attr[0] == "fe")
+                m_settings[index].m_fe_number = atoi(attr[1].c_str());
 		}
 	}
 }

--- a/option.h
+++ b/option.h
@@ -33,9 +33,10 @@ public:
 	std::string m_ipaddr;
 	bool m_tcpdata;
 	int m_fe_type;
-        bool m_force_plts;
+	int m_fe_number;
+	bool m_force_plts;
 
-	vtunerOpt():m_tcpdata(0),m_fe_type(-1),m_force_plts(false)
+	vtunerOpt():m_tcpdata(0),m_fe_type(-1),m_fe_number(0),m_force_plts(false)
 	{
 	}
 


### PR DESCRIPTION
This is useful when there are multiple adapters connected to different satellites.
If the user specifies a certain fe=  in /etc/vtuner.conf, that will be honored by the satip server.